### PR TITLE
Add workflow to run data tests

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -1,0 +1,31 @@
+name: Data Tests
+
+on: [push, pull_request]
+
+jobs:
+  duplicate_entries:
+    name: Duplicate entries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Check out data
+      uses: actions/checkout@v2.3.4
+      with:
+        path: data
+
+    - name: Check out data tests
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: openelections/openelections-data-tests
+        ref: v0.1.1
+        path: data_tests
+
+    - name: Run data tests
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py duplicate_entries ${{ github.workspace }}/data

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# openelections-data-nm [![Build Status](https://github.com/openelections/openelections-data-nm/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-nm/actions)
+[![Build Status](https://github.com/openelections/openelections-data-nm/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-nm/actions)
+[![Build Status](https://github.com/openelections/openelections-data-nm/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-nm/actions)
+
+# openelections-data-nm
 New Mexico elects 70 House members and statewide officers (Governor, Lt. Gov(primary only), Auditor, Treasurer, Attorney General, Commissioner of Public Lands) in non-presidential years.
 
 In presidential election years, all 70 House seats and 42 Senate seats are up for election.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/openelections/openelections-data-nm/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-nm/actions)
-[![Build Status](https://github.com/openelections/openelections-data-nm/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-nm/actions)
+[![Build Status](https://github.com/openelections/openelections-data-nm/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-nm/actions/workflows/data_tests.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/openelections/openelections-data-nm/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-nm/actions/workflows/format_tests.yml?query=branch%3Amaster)
 
 # openelections-data-nm
 New Mexico elects 70 House members and statewide officers (Governor, Lt. Gov(primary only), Auditor, Treasurer, Attorney General, Commissioner of Public Lands) in non-presidential years.


### PR DESCRIPTION
This adds a workflow to run the [data validation](https://github.com/openelections/openelections-data-tests) tests. This currently consists of a single job that checks for duplicate entries in the data files.